### PR TITLE
transactionprocessor: move NewContext call to "constructor"

### DIFF
--- a/transactionprocessor.go
+++ b/transactionprocessor.go
@@ -27,16 +27,15 @@ type TransactionProcessor struct {
 func NewTransactionProcessor(card *emv.Card) *TransactionProcessor {
 	return &TransactionProcessor{
 		card: card,
+		ctx: emv.NewContext(card, &emv.ContextConfig{
+			Terminal: emv.Terminal{
+				CountryCode: []byte{0x00, 0x76},
+			},
+		}, &fileCertificateManager{"./certs"}),
 	}
 }
 
 func (t *TransactionProcessor) Initialize() error {
-	t.ctx = emv.NewContext(t.card, &emv.ContextConfig{
-		Terminal: emv.Terminal{
-			CountryCode: []byte{0x00, 0x76},
-		},
-	}, &fileCertificateManager{"./certs"})
-
 	err := t.ctx.Initialize()
 
 	if err != nil {


### PR DESCRIPTION
IMO the "constructor" should create all member variables
and the Initialize method should initialize everything
related to the structure.

Of course this is opinion, it doesn't affect how the project functions, you can close this if you think it is not what you want 🙂 

By the way, thank you very much for the project, I am trying to reverse engineer it and it is helping me to find out how EMV works :heart: