### PR TITLE
Fix/naming convention

### DIFF
--- a/emv/publickey.go
+++ b/emv/publickey.go
@@ -14,16 +14,16 @@ func NewPublicKey(e, m *big.Int) *PublicKey {
 	}
 }
 
-func (r *PublicKey) Decrypt(data []byte) ([]byte, error) {
+func (pk *PublicKey) Decrypt(data []byte) ([]byte, error) {
 	num := big.NewInt(0)
 	num.SetBytes(data)
 
 	result := big.NewInt(0)
-	result.Exp(num, r.exponent, r.modulus)
+	result.Exp(num, pk.exponent, pk.modulus)
 
 	return result.Bytes(), nil
 }
 
-func (r *PublicKey) Modulus() []byte {
-	return r.modulus.Bytes()
+func (pk *PublicKey) Modulus() []byte {
+	return pk.modulus.Bytes()
 }


### PR DESCRIPTION
Some structs had methods that the variable names were of a letter completely different from any of the initials on the struct itself.

I don't know if this was made on purpose, if it has, tell me why please :)

Since I didn't know why, and it felt kind of weird/wrong, I've decided to do this Pull Request.
