### PR TITLE
transactionprocessor: move hints from main to it

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,25 +6,6 @@ import (
 	"github.com/greenboxal/emv-kernel/emv"
 )
 
-var hints = []emv.ApplicationHint{
-	emv.ApplicationHint{
-		Name:    []byte{0xA0, 0x00, 0x00, 0x00, 0x04, 0x10, 0x10},
-		Partial: false,
-	},
-	emv.ApplicationHint{
-		Name:    []byte{0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10},
-		Partial: false,
-	},
-	emv.ApplicationHint{
-		Name:    []byte{0xA0, 0x00, 0x00, 0x00, 0x25, 0x01},
-		Partial: true,
-	},
-	emv.ApplicationHint{
-		Name:    []byte{0xA0, 0x00},
-		Partial: true,
-	},
-}
-
 func getCard() (*scard.Card, error) {
 	ctx, err := scard.EstablishContext()
 

--- a/transactionprocessor.go
+++ b/transactionprocessor.go
@@ -67,6 +67,25 @@ func (t *TransactionProcessor) Initialize() error {
 	return nil
 }
 
+var hints = []emv.ApplicationHint{
+	emv.ApplicationHint{
+		Name:    []byte{0xA0, 0x00, 0x00, 0x00, 0x04, 0x10, 0x10},
+		Partial: false,
+	},
+	emv.ApplicationHint{
+		Name:    []byte{0xA0, 0x00, 0x00, 0x00, 0x03, 0x10, 0x10},
+		Partial: false,
+	},
+	emv.ApplicationHint{
+		Name:    []byte{0xA0, 0x00, 0x00, 0x00, 0x25, 0x01},
+		Partial: true,
+	},
+	emv.ApplicationHint{
+		Name:    []byte{0xA0, 0x00},
+		Partial: true,
+	},
+}
+
 func (t *TransactionProcessor) selectApplication() (*emv.ApplicationInformation, error) {
 	applications, err := t.ctx.ListApplications(false, hints)
 


### PR DESCRIPTION
This move is happening, since the `hints` variable
is used only on `transactionprocessor.go` file.